### PR TITLE
Bugfix/route version scope fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/Release
 node_modules
 .DS_Store
 sftp-config.json
+.vscode

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ server.register({
 
 Used to obtain the assigned handler for a plugin's requested route. `Request.path` is not used because its uniqueness may not be consistent. It performs two different checks in order to find a routes handler. 
 
-1. plugin name + request.paramsArray + request.route.version
+1. plugin name + request.paramsArray + request.app.requestVersion
 2. plugin name + request.paramsArray
 
-You have the ability to create versioned routes and still keep the URL path consistent.  The request.route.version is currently the location checked for versioned or A/B tested routes. For this to be successful you will need another method outside hapi-direct to set this value or A/B scenario. 
+You have the ability to create versioned routes and still keep the URL path consistent.  The request.app.routeVersion is currently the location checked for versioned or A/B tested routes. For this to be successful you will need another method outside hapi-direct to set this value or A/B scenario. 
 
 For example the an application I work with makes use of a simple resource security module that speaks with a backend database to determine the feature versions I have access too. Of course if this value does not exist hapi-direct proceeds by checking without an appended version.
 
@@ -84,7 +84,7 @@ The return result is a flat object of cached required handlers.  If this object 
 
 ### directRoute
 
-Takes the plugin of the requested route and determines if a handler exists for it or returns 404. The handler object that you previously populated and exposed during the plugin register is now checked against the `request.paramsArray` and `request.route.version` if present.
+Takes the plugin of the requested route and determines if a handler exists for it or returns 404. The handler object that you previously populated and exposed during the plugin register is now checked against the `request.paramsArray` and `request.app.routeVersion` if present.
 
 Then you can execute this within the route handler as `server.methods.directRoute`.
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,6 @@ exports.register = (server, options, next) => {
 		],
 		function(e, result){
 			if (e) {
-				console.log(request.server.plugins[request.route.realm.plugin])
 				return reply(boom.notFound('Not Found'));
 			}
 			return result(request, reply);

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.register = (server, options, next) => {
 		async.tryEach([
 			function(cb) {
 				try {
-					let handler = request.server.plugins[request.route.realm.plugin].handlers[path.join(uriParams, request.route.version)];
+					let handler = request.server.plugins[request.route.realm.plugin].handlers[path.join(uriParams, request.app.routeVersion)];
 
 					if (handler && !(handler instanceof Error)) {
 						return cb(null, handler);
@@ -42,6 +42,7 @@ exports.register = (server, options, next) => {
 		],
 		function(e, result){
 			if (e) {
+				console.log(request.server.plugins[request.route.realm.plugin])
 				return reply(boom.notFound('Not Found'));
 			}
 			return result(request, reply);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-direct",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Dynamic Hapi route handling through directory structure",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -111,7 +111,7 @@ describe('hapi-direct', () => {
 		});
 	});
 
-	it('Call to directRoute does find an assigned route handler with set request.route.version, return 200', function(done) {
+	it('Call to directRoute does find an assigned route handler with set request.app.routeVersion, return 200', function(done) {
 		const thisServer = new Hapi.Server();
 		const testPlugin = function (srv, options, next) {
 			srv.expose('handlers', srv.methods.assignHandlers(__dirname));
@@ -121,7 +121,7 @@ describe('hapi-direct', () => {
 				handler: srv.methods.directRoute
 			});
 			srv.ext('onPreHandler', (req, rep) => {
-				req.route.version = 'v1';
+				req.app.routeVersion = 'v1';
 				rep.continue();
 			});
 			return next();
@@ -145,7 +145,7 @@ describe('hapi-direct', () => {
 		});
 	});
 
-	it('Call to directRoute does not find an assigned route handler with set request.route.version, return 404', function(done) {
+	it('Call to directRoute does not find an assigned route handler with set request.app.routeVersion, return 404', function(done) {
 		const thisServer = new Hapi.Server();
 		const testPlugin = function (srv, options, next) {
 			srv.expose('handlers', srv.methods.assignHandlers(__dirname));
@@ -155,7 +155,7 @@ describe('hapi-direct', () => {
 				handler: srv.methods.directRoute
 			});
 			srv.ext('onPreHandler', (req, rep) => {
-				req.route.version = 'v2';
+				req.app.routeVersion = 'v2';
 				rep.continue();
 			});
 			return next();


### PR DESCRIPTION
#1 

Change the version check to no longer look at request.route.version which is a shared scope among requests in hapi. A high enough requests per minute would cause this value to be incorrect and stepped on and overridden by another request. Rather make use of request.app which is a container for application state per request, you get a new one for each request.